### PR TITLE
Fix CLI build for BrickGame

### DIFF
--- a/BrickGame_v2/src/gui/cli/main.c
+++ b/BrickGame_v2/src/gui/cli/main.c
@@ -1,3 +1,4 @@
+#define _DEFAULT_SOURCE
 #include "../../brick_game/common/brick_game.h"
 #include "design.h"
 #include <ncurses.h>


### PR DESCRIPTION
## Summary
- fix `usleep` declaration in CLI by defining `_DEFAULT_SOURCE`
- confirm building CLI and libraries

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_6867c936e968832490f1020c009b902c